### PR TITLE
Remove native flag and add kernel,stdlib to app deps

### DIFF
--- a/src/bear.app.src
+++ b/src/bear.app.src
@@ -3,6 +3,6 @@
   {description, ""},
   {vsn, git},
   {registered, []},
-  {applications, []},
+  {applications, [kernel, stdlib]},
   {env, []}
  ]}.

--- a/src/bear.erl
+++ b/src/bear.erl
@@ -39,7 +39,6 @@
 -record(scan_result, {n=0, sumX=0, sumXX=0, sumInv=0, sumLog, max, min}).
 -record(scan_result2, {x2=0, x3=0, x4=0}).
 
--compile([native]).
 
 get_statistics(Values) when length(Values) < ?STATS_MIN ->
     [


### PR DESCRIPTION
With Riak, we ship an erlang VM without HiPE which causes
warnings when bear tries to use the `native` flag to compile.

Also, this commit adds [kernel,stdlib] to bear's application
list in the .app file.  This hopefully will help with shutdown
issues in riak when applications aren't unloaded properly.
